### PR TITLE
Pin confy version to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,8 @@ dependencies = [
 [[package]]
 name = "confy"
 version = "0.4.0"
-source = "git+https://github.com/rust-cli/confy#baf2b401c9b4e783599ac8c74a6a9829a27f0deb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2913470204e9e8498a0f31f17f90a0de801ae92c8c5ac18c49af4819e6786697"
 dependencies = [
  "directories",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 chrono = "0.4"
 clap = "3.0.0-beta.2"
+confy = "0.4"
 dirs = "2"
 git2 = "0.13"
 hostname = "0.3"
@@ -29,9 +30,6 @@ rust-ini = "0.15"
 url = "2"
 shellexpand = "2.0"
 sysinfo = "0.15"
-
-[dependencies.confy]
-git = "https://github.com/rust-cli/confy"
 
 [target.'cfg(not(windows))'.dependencies]
 users = "0.10"


### PR DESCRIPTION
Resolves https://github.com/reujab/silver/issues/74

`silver` currently uses the `master` branch of `confy`, which lead to the breaking change mentioned above.

This PR works around this by pinning the latest released version, which is compatible with this code base. When the next version of confy is released, the call to `confy::load("silver")` in `main.rst` will need to be replaced with `confy::load("silver", None)`

The deeper issue still needs to be fixed: the dependency should have a pinned version. Building off master is begging for incompatibilities like this in the future.